### PR TITLE
Upgrading Clojure version to 1.6.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,7 @@
 		<dependency>
 			<groupId>org.clojure</groupId>
 			<artifactId>clojure</artifactId>
-			<version>1.3.0</version>
+			<version>1.6.0</version>
 		</dependency>
 
 		<!-- Test dependencies -->


### PR DESCRIPTION
All this does is change the Clojure version from 1.3 to 1.6.

I don't have anything setup to build locally (i.e. I haven't tested this in a proper build). However, when I swap out the Clojure jar in Fiji my Clojure scripts still work as expected.

If there are any issues I would be happy to fix them.

Thank you,
Kyle
